### PR TITLE
feat: end-frame conditioning via guiding-token appending for all pipelines

### DIFF
--- a/mlx_video/models/ltx_2/generate.py
+++ b/mlx_video/models/ltx_2/generate.py
@@ -483,8 +483,17 @@ def denoise_distilled(
     audio_positions: Optional[mx.array] = None,
     audio_embeddings: Optional[mx.array] = None,
     audio_frozen: bool = False,
+    guiding_tokens: Optional[mx.array] = None,
+    guiding_positions: Optional[mx.array] = None,
+    guiding_strength: float = 1.0,
 ) -> tuple[mx.array, Optional[mx.array]]:
-    """Run denoising loop for distilled pipeline (no CFG)."""
+    """Run denoising loop for distilled pipeline (no CFG).
+
+    guiding_tokens/guiding_positions: end-frame conditioning via token appending
+    (LTX-2 KeyframeIndex approach). Tokens are appended to the video sequence
+    before the transformer so the model attends to them without hard-replacing
+    any video token, producing smoother transitions to the target end frame.
+    """
     dtype = latents.dtype
     enable_audio = audio_latents is not None
 
@@ -528,10 +537,31 @@ def denoise_distilled(
             else:
                 timesteps = mx.full((b, num_tokens), sigma, dtype=dtype)
 
+            # Append guiding tokens (end-frame keyframe conditioning).
+            # Tokens are appended to the sequence so the transformer attends to
+            # them without replacing any video token — avoids the hard boundary
+            # that causes abrupt appearance changes near the end frame.
+            if guiding_tokens is not None:
+                n_cond = guiding_tokens.shape[1]
+                cond_ts = mx.full(
+                    (b, n_cond),
+                    sigma * (1.0 - guiding_strength),
+                    dtype=dtype,
+                )
+                seq_latent = mx.concatenate(
+                    [latents_flat, guiding_tokens.astype(dtype)], axis=1
+                )
+                seq_timesteps = mx.concatenate([timesteps, cond_ts], axis=1)
+                seq_positions = mx.concatenate([positions, guiding_positions], axis=2)
+            else:
+                seq_latent = latents_flat
+                seq_timesteps = timesteps
+                seq_positions = positions
+
             video_modality = Modality(
-                latent=latents_flat,
-                timesteps=timesteps,
-                positions=positions,
+                latent=seq_latent,
+                timesteps=seq_timesteps,
+                positions=seq_positions,
                 context=text_embeddings,
                 context_mask=None,
                 enabled=True,
@@ -568,6 +598,9 @@ def denoise_distilled(
             velocity, audio_velocity = transformer(
                 video=video_modality, audio=audio_modality
             )
+            # Drop guiding token outputs — only use velocity for the video tokens.
+            if guiding_tokens is not None:
+                velocity = velocity[:, :num_tokens, :]
             mx.eval(velocity)
             if audio_velocity is not None:
                 mx.eval(audio_velocity)
@@ -1677,28 +1710,49 @@ def _build_i2v_conditionings(
     image_latent,
     image_frame_idx: int,
     image_strength: float,
-    end_image_latent=None,
-    end_image_strength: float = 1.0,
 ):
-    """Build a list of VideoConditionByLatentIndex for I2V conditioning.
-
-    Supports first-frame, last-frame, or both simultaneously.
-    """
+    """Build a list of VideoConditionByLatentIndex for first-frame I2V conditioning."""
     conditionings = []
     if image_latent is not None:
-        idx = 0 if end_image_latent is not None else image_frame_idx
         conditionings.append(
             VideoConditionByLatentIndex(
-                latent=image_latent, frame_idx=idx, strength=image_strength
-            )
-        )
-    if end_image_latent is not None:
-        conditionings.append(
-            VideoConditionByLatentIndex(
-                latent=end_image_latent, frame_idx=-1, strength=end_image_strength
+                latent=image_latent, frame_idx=image_frame_idx, strength=image_strength
             )
         )
     return conditionings
+
+
+def _prepare_guiding_tokens(
+    cond_latent: mx.array,
+    positions: mx.array,
+    latent_frames: int,
+    h: int,
+    w: int,
+) -> tuple:
+    """Prepare end-frame conditioning tokens for token-appending guidance.
+
+    Flattens the conditioning latent to token form and extracts the positional
+    encoding of the last latent frame so they can be appended to the video
+    sequence before the transformer forward pass (no hard token replacement,
+    which avoids abrupt appearance changes near the end frame).
+
+    Args:
+        cond_latent: Encoded end-image latent, shape (1, C, 1, h, w)
+        positions: Full position grid, shape (B, 3, F*h*w, 2)
+        latent_frames: Total number of latent frames F
+        h: Latent height
+        w: Latent width
+
+    Returns:
+        tokens: (1, h*w, C) conditioning tokens
+        frame_positions: (B, 3, h*w, 2) positions for the last latent frame
+    """
+    c = cond_latent.shape[1]
+    tokens = mx.transpose(mx.reshape(cond_latent, (1, c, -1)), (0, 2, 1))
+    start = (latent_frames - 1) * h * w
+    end = latent_frames * h * w
+    frame_positions = positions[:, :, start:end, :]
+    return tokens, frame_positions
 
 
 def generate_video(
@@ -2142,18 +2196,18 @@ def generate_video(
         )
         mx.eval(audio_positions, audio_latents)
 
-        # Apply I2V conditioning
+        # Apply I2V conditioning (first frame via replace, end frame via guiding tokens)
         state1 = None
-        if is_i2v and (stage1_image_latent is not None or stage1_end_image_latent is not None):
+        if stage1_image_latent is not None:
             latent_shape = (1, 128, latent_frames, stage1_h, stage1_w)
             state1 = LatentState(
                 latent=mx.zeros(latent_shape, dtype=model_dtype),
                 clean_latent=mx.zeros(latent_shape, dtype=model_dtype),
                 denoise_mask=mx.ones((1, 1, latent_frames, 1, 1), dtype=model_dtype),
             )
+            first_frame_idx = 0 if has_end_image else image_frame_idx
             conditionings = _build_i2v_conditionings(
-                stage1_image_latent, image_frame_idx, image_strength,
-                stage1_end_image_latent, end_image_strength,
+                stage1_image_latent, first_frame_idx, image_strength,
             )
             state1 = apply_conditioning(state1, conditionings)
 
@@ -2167,12 +2221,17 @@ def generate_video(
                 denoise_mask=state1.denoise_mask,
             )
             latents = state1.latent
-            mx.eval(latents)
         else:
             latents = mx.random.normal(
                 (1, 128, latent_frames, stage1_h, stage1_w), dtype=model_dtype
             )
-            mx.eval(latents)
+        mx.eval(latents)
+
+        s1_guiding_tokens, s1_guiding_positions = None, None
+        if stage1_end_image_latent is not None:
+            s1_guiding_tokens, s1_guiding_positions = _prepare_guiding_tokens(
+                stage1_end_image_latent, positions, latent_frames, stage1_h, stage1_w
+            )
 
         latents, audio_latents = denoise_distilled(
             latents,
@@ -2186,6 +2245,9 @@ def generate_video(
             audio_positions=audio_positions,
             audio_embeddings=audio_embeddings,
             audio_frozen=is_a2v,
+            guiding_tokens=s1_guiding_tokens,
+            guiding_positions=s1_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
         # Upsample latents
@@ -2221,15 +2283,15 @@ def generate_video(
         mx.eval(positions)
 
         state2 = None
-        if is_i2v and (stage2_image_latent is not None or stage2_end_image_latent is not None):
+        if stage2_image_latent is not None:
             state2 = LatentState(
                 latent=latents,
                 clean_latent=mx.zeros_like(latents),
                 denoise_mask=mx.ones((1, 1, latent_frames, 1, 1), dtype=model_dtype),
             )
+            first_frame_idx = 0 if has_end_image else image_frame_idx
             conditionings = _build_i2v_conditionings(
-                stage2_image_latent, image_frame_idx, image_strength,
-                stage2_end_image_latent, end_image_strength,
+                stage2_image_latent, first_frame_idx, image_strength,
             )
             state2 = apply_conditioning(state2, conditionings)
 
@@ -2250,6 +2312,13 @@ def generate_video(
             noise = mx.random.normal(latents.shape).astype(model_dtype)
             latents = noise * noise_scale + latents * one_minus_scale
             mx.eval(latents)
+
+        s2_guiding_tokens, s2_guiding_positions = None, None
+        if stage2_end_image_latent is not None:
+            positions2 = create_position_grid(1, latent_frames, stage2_h, stage2_w)
+            s2_guiding_tokens, s2_guiding_positions = _prepare_guiding_tokens(
+                stage2_end_image_latent, positions2, latent_frames, stage2_h, stage2_w
+            )
 
         # Re-noise audio at sigma=0.909375 for joint refinement (matches PyTorch)
         if audio_latents is not None and not is_a2v:
@@ -2273,6 +2342,9 @@ def generate_video(
             audio_positions=audio_positions,
             audio_embeddings=audio_embeddings,
             audio_frozen=is_a2v,
+            guiding_tokens=s2_guiding_tokens,
+            guiding_positions=s2_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
     elif pipeline == PipelineType.DEV:
@@ -2335,7 +2407,7 @@ def generate_video(
         # Initialize latents with optional I2V conditioning
         video_state = None
         video_latent_shape = (1, 128, latent_frames, latent_h, latent_w)
-        if is_i2v and (image_latent is not None or end_image_latent is not None):
+        if is_i2v and image_latent is not None:
             video_state = LatentState(
                 latent=mx.zeros(video_latent_shape, dtype=model_dtype),
                 clean_latent=mx.zeros(video_latent_shape, dtype=model_dtype),
@@ -2343,7 +2415,6 @@ def generate_video(
             )
             conditionings = _build_i2v_conditionings(
                 image_latent, image_frame_idx, image_strength,
-                end_image_latent, end_image_strength,
             )
             video_state = apply_conditioning(video_state, conditionings)
 
@@ -2466,7 +2537,7 @@ def generate_video(
         # Apply I2V conditioning for stage 1
         state1 = None
         stage1_shape = (1, 128, latent_frames, stage1_h, stage1_w)
-        if is_i2v and (stage1_image_latent is not None or stage1_end_image_latent is not None):
+        if is_i2v and stage1_image_latent is not None:
             state1 = LatentState(
                 latent=mx.zeros(stage1_shape, dtype=model_dtype),
                 clean_latent=mx.zeros(stage1_shape, dtype=model_dtype),
@@ -2474,7 +2545,6 @@ def generate_video(
             )
             conditionings = _build_i2v_conditionings(
                 stage1_image_latent, image_frame_idx, image_strength,
-                stage1_end_image_latent, end_image_strength,
             )
             state1 = apply_conditioning(state1, conditionings)
 
@@ -2575,7 +2645,7 @@ def generate_video(
         mx.eval(positions)
 
         state2 = None
-        if is_i2v and (stage2_image_latent is not None or stage2_end_image_latent is not None):
+        if is_i2v and stage2_image_latent is not None:
             state2 = LatentState(
                 latent=latents,
                 clean_latent=mx.zeros_like(latents),
@@ -2583,7 +2653,6 @@ def generate_video(
             )
             conditionings = _build_i2v_conditionings(
                 stage2_image_latent, image_frame_idx, image_strength,
-                stage2_end_image_latent, end_image_strength,
             )
             state2 = apply_conditioning(state2, conditionings)
 
@@ -2741,7 +2810,7 @@ def generate_video(
         # Apply I2V conditioning for stage 1
         state1 = None
         stage1_shape = (1, 128, latent_frames, stage1_h, stage1_w)
-        if is_i2v and (stage1_image_latent is not None or stage1_end_image_latent is not None):
+        if is_i2v and stage1_image_latent is not None:
             state1 = LatentState(
                 latent=mx.zeros(stage1_shape, dtype=model_dtype),
                 clean_latent=mx.zeros(stage1_shape, dtype=model_dtype),
@@ -2749,7 +2818,6 @@ def generate_video(
             )
             conditionings = _build_i2v_conditionings(
                 stage1_image_latent, image_frame_idx, image_strength,
-                stage1_end_image_latent, end_image_strength,
             )
             state1 = apply_conditioning(state1, conditionings)
 
@@ -2841,7 +2909,7 @@ def generate_video(
         mx.eval(positions)
 
         state2 = None
-        if is_i2v and (stage2_image_latent is not None or stage2_end_image_latent is not None):
+        if is_i2v and stage2_image_latent is not None:
             state2 = LatentState(
                 latent=latents,
                 clean_latent=mx.zeros_like(latents),
@@ -2849,7 +2917,6 @@ def generate_video(
             )
             conditionings = _build_i2v_conditionings(
                 stage2_image_latent, image_frame_idx, image_strength,
-                stage2_end_image_latent, end_image_strength,
             )
             state2 = apply_conditioning(state2, conditionings)
 

--- a/mlx_video/models/ltx_2/generate.py
+++ b/mlx_video/models/ltx_2/generate.py
@@ -887,6 +887,9 @@ def denoise_dev_av(
     stg_audio_blocks: Optional[list] = None,
     modality_scale: float = 1.0,
     audio_frozen: bool = False,
+    guiding_tokens: Optional[mx.array] = None,
+    guiding_positions: Optional[mx.array] = None,
+    guiding_strength: float = 1.0,
 ) -> tuple[mx.array, mx.array]:
     """Run denoising loop for dev pipeline with CFG/APG, STG, modality guidance, and audio.
 
@@ -942,6 +945,24 @@ def denoise_dev_av(
         double_precision=transformer.config.double_precision_rope,
     )
     mx.eval(precomputed_video_rope, precomputed_audio_rope)
+
+    # Pre-compute extended RoPE covering video + guiding tokens (once, outside loop).
+    n_guiding = 0
+    extended_video_rope = precomputed_video_rope
+    if guiding_tokens is not None:
+        n_guiding = guiding_tokens.shape[1]
+        extended_positions = mx.concatenate([video_positions, guiding_positions], axis=2)
+        extended_video_rope = precompute_freqs_cis(
+            extended_positions,
+            dim=transformer.inner_dim,
+            theta=transformer.positional_embedding_theta,
+            max_pos=transformer.positional_embedding_max_pos,
+            use_middle_indices_grid=transformer.use_middle_indices_grid,
+            num_attention_heads=transformer.num_attention_heads,
+            rope_type=transformer.rope_type,
+            double_precision=transformer.config.double_precision_rope,
+        )
+        mx.eval(extended_video_rope)
 
     with Progress(
         SpinnerColumn(),
@@ -1001,14 +1022,28 @@ def denoise_dev_av(
                 if audio_frozen
                 else mx.full((ab,), sigma, dtype=dtype)
             )
+
+            # Build extended sequence if end-frame guiding tokens are active.
+            if guiding_tokens is not None:
+                cond_ts = mx.full(
+                    (b, n_guiding), sigma * (1.0 - guiding_strength), dtype=dtype
+                )
+                seq_video_flat = mx.concatenate(
+                    [video_flat, guiding_tokens.astype(dtype)], axis=1
+                )
+                seq_video_timesteps = mx.concatenate([video_timesteps, cond_ts], axis=1)
+            else:
+                seq_video_flat = video_flat
+                seq_video_timesteps = video_timesteps
+
             video_modality_pos = Modality(
-                latent=video_flat,
-                timesteps=video_timesteps,
+                latent=seq_video_flat,
+                timesteps=seq_video_timesteps,
                 positions=video_positions,
                 context=video_embeddings_pos,
                 context_mask=None,
                 enabled=True,
-                positional_embeddings=precomputed_video_rope,
+                positional_embeddings=extended_video_rope,
                 sigma=sigma_array,
             )
             audio_modality_pos = Modality(
@@ -1024,6 +1059,8 @@ def denoise_dev_av(
             video_vel_pos, audio_vel_pos = transformer(
                 video=video_modality_pos, audio=audio_modality_pos
             )
+            if guiding_tokens is not None:
+                video_vel_pos = video_vel_pos[:, :num_video_tokens, :]
             mx.eval(video_vel_pos, audio_vel_pos)
 
             # Convert velocity to denoised (x0) using per-token timesteps
@@ -1057,13 +1094,13 @@ def denoise_dev_av(
             # Pass 2: CFG (negative conditioning)
             if use_cfg:
                 video_modality_neg = Modality(
-                    latent=video_flat,
-                    timesteps=video_timesteps,
+                    latent=seq_video_flat,
+                    timesteps=seq_video_timesteps,
                     positions=video_positions,
                     context=video_embeddings_neg,
                     context_mask=None,
                     enabled=True,
-                    positional_embeddings=precomputed_video_rope,
+                    positional_embeddings=extended_video_rope,
                     sigma=sigma_array,
                 )
                 audio_modality_neg = Modality(
@@ -1079,6 +1116,8 @@ def denoise_dev_av(
                 video_vel_neg, audio_vel_neg = transformer(
                     video=video_modality_neg, audio=audio_modality_neg
                 )
+                if guiding_tokens is not None:
+                    video_vel_neg = video_vel_neg[:, :num_video_tokens, :]
                 mx.eval(video_vel_neg, audio_vel_neg)
 
                 video_x0_neg_f32 = (
@@ -1114,6 +1153,8 @@ def denoise_dev_av(
                     stg_video_blocks=stg_video_blocks,
                     stg_audio_blocks=stg_audio_blocks,
                 )
+                if guiding_tokens is not None:
+                    video_vel_ptb = video_vel_ptb[:, :num_video_tokens, :]
                 mx.eval(video_vel_ptb, audio_vel_ptb)
 
                 video_x0_ptb_f32 = (
@@ -1139,6 +1180,8 @@ def denoise_dev_av(
                     audio=audio_modality_pos,
                     skip_cross_modal=True,
                 )
+                if guiding_tokens is not None:
+                    video_vel_iso = video_vel_iso[:, :num_video_tokens, :]
                 mx.eval(video_vel_iso, audio_vel_iso)
 
                 video_x0_iso_f32 = (
@@ -1235,6 +1278,9 @@ def denoise_res2s_av(
     bongmath: bool = True,
     bongmath_max_iter: int = 100,
     audio_frozen: bool = False,
+    guiding_tokens: Optional[mx.array] = None,
+    guiding_positions: Optional[mx.array] = None,
+    guiding_strength: float = 1.0,
 ) -> tuple[mx.array, mx.array]:
     """Run res_2s second-order denoising loop with CFG/STG/modality guidance.
 
@@ -1302,6 +1348,24 @@ def denoise_res2s_av(
     )
     mx.eval(precomputed_video_rope, precomputed_audio_rope)
 
+    # Pre-compute extended RoPE for guiding tokens (once, outside loop).
+    n_guiding = 0
+    extended_video_rope = precomputed_video_rope
+    if guiding_tokens is not None:
+        n_guiding = guiding_tokens.shape[1]
+        extended_positions = mx.concatenate([video_positions, guiding_positions], axis=2)
+        extended_video_rope = precompute_freqs_cis(
+            extended_positions,
+            dim=transformer.inner_dim,
+            theta=transformer.positional_embedding_theta,
+            max_pos=transformer.positional_embedding_max_pos,
+            use_middle_indices_grid=transformer.use_middle_indices_grid,
+            num_attention_heads=transformer.num_attention_heads,
+            rope_type=transformer.rope_type,
+            double_precision=transformer.config.double_precision_rope,
+        )
+        mx.eval(extended_video_rope)
+
     phi_cache = {}
     c2 = 0.5
 
@@ -1342,15 +1406,28 @@ def denoise_res2s_av(
             else mx.full((ab,), sigma, dtype=dtype)
         )
 
+        # Build extended sequence if end-frame guiding tokens are active.
+        if guiding_tokens is not None:
+            cond_ts = mx.full(
+                (b, n_guiding), sigma * (1.0 - guiding_strength), dtype=dtype
+            )
+            seq_video_flat = mx.concatenate(
+                [video_flat, guiding_tokens.astype(dtype)], axis=1
+            )
+            seq_video_timesteps = mx.concatenate([video_timesteps, cond_ts], axis=1)
+        else:
+            seq_video_flat = video_flat
+            seq_video_timesteps = video_timesteps
+
         # Pass 1: Positive conditioning
         video_modality_pos = Modality(
-            latent=video_flat,
-            timesteps=video_timesteps,
+            latent=seq_video_flat,
+            timesteps=seq_video_timesteps,
             positions=video_positions,
             context=video_embeddings_pos,
             context_mask=None,
             enabled=True,
-            positional_embeddings=precomputed_video_rope,
+            positional_embeddings=extended_video_rope,
             sigma=sigma_array,
         )
         audio_modality_pos = Modality(
@@ -1366,6 +1443,8 @@ def denoise_res2s_av(
         video_vel_pos, audio_vel_pos = transformer(
             video=video_modality_pos, audio=audio_modality_pos
         )
+        if guiding_tokens is not None:
+            video_vel_pos = video_vel_pos[:, :num_video_tokens, :]
         mx.eval(video_vel_pos, audio_vel_pos)
 
         # Convert velocity to x0
@@ -1385,13 +1464,13 @@ def denoise_res2s_av(
         # Pass 2: CFG
         if use_cfg:
             video_modality_neg = Modality(
-                latent=video_flat,
-                timesteps=video_timesteps,
+                latent=seq_video_flat,
+                timesteps=seq_video_timesteps,
                 positions=video_positions,
                 context=video_embeddings_neg,
                 context_mask=None,
                 enabled=True,
-                positional_embeddings=precomputed_video_rope,
+                positional_embeddings=extended_video_rope,
                 sigma=sigma_array,
             )
             audio_modality_neg = Modality(
@@ -1407,6 +1486,8 @@ def denoise_res2s_av(
             video_vel_neg, audio_vel_neg = transformer(
                 video=video_modality_neg, audio=audio_modality_neg
             )
+            if guiding_tokens is not None:
+                video_vel_neg = video_vel_neg[:, :num_video_tokens, :]
             mx.eval(video_vel_neg, audio_vel_neg)
 
             video_x0_neg = video_flat_f32 - video_ts_f32 * video_vel_neg.astype(
@@ -1431,6 +1512,8 @@ def denoise_res2s_av(
                 stg_video_blocks=stg_video_blocks,
                 stg_audio_blocks=stg_audio_blocks,
             )
+            if guiding_tokens is not None:
+                video_vel_ptb = video_vel_ptb[:, :num_video_tokens, :]
             mx.eval(video_vel_ptb, audio_vel_ptb)
 
             video_x0_ptb = video_flat_f32 - video_ts_f32 * video_vel_ptb.astype(
@@ -1454,6 +1537,8 @@ def denoise_res2s_av(
                 audio=audio_modality_pos,
                 skip_cross_modal=True,
             )
+            if guiding_tokens is not None:
+                video_vel_iso = video_vel_iso[:, :num_video_tokens, :]
             mx.eval(video_vel_iso, audio_vel_iso)
 
             video_x0_iso = video_flat_f32 - video_ts_f32 * video_vel_iso.astype(
@@ -2433,6 +2518,12 @@ def generate_video(
             latents = mx.random.normal(video_latent_shape, dtype=model_dtype)
             mx.eval(latents)
 
+        dev_guiding_tokens, dev_guiding_positions = None, None
+        if end_image_latent is not None:
+            dev_guiding_tokens, dev_guiding_positions = _prepare_guiding_tokens(
+                end_image_latent, video_positions, latent_frames, latent_h, latent_w
+            )
+
         # Always use A/V denoising - PyTorch always processes audio+video jointly
         latents, audio_latents = denoise_dev_av(
             latents,
@@ -2458,6 +2549,9 @@ def generate_video(
             stg_audio_blocks=stg_blocks,
             modality_scale=modality_scale,
             audio_frozen=is_a2v,
+            guiding_tokens=dev_guiding_tokens,
+            guiding_positions=dev_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
         # Load VAE decoder (for dev pipeline, loaded here instead of during upsampling)
@@ -2563,6 +2657,12 @@ def generate_video(
             latents = mx.random.normal(stage1_shape, dtype=model_dtype)
             mx.eval(latents)
 
+        s1_guiding_tokens, s1_guiding_positions = None, None
+        if stage1_end_image_latent is not None:
+            s1_guiding_tokens, s1_guiding_positions = _prepare_guiding_tokens(
+                stage1_end_image_latent, positions, latent_frames, stage1_h, stage1_w
+            )
+
         # Stage 1: Always use joint AV denoising (matches PyTorch)
         latents, audio_latents = denoise_dev_av(
             latents,
@@ -2588,6 +2688,9 @@ def generate_video(
             stg_audio_blocks=stg_blocks,
             modality_scale=modality_scale,
             audio_frozen=is_a2v,
+            guiding_tokens=s1_guiding_tokens,
+            guiding_positions=s1_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
         mx.eval(audio_latents)
@@ -2683,6 +2786,13 @@ def generate_video(
             )
             mx.eval(audio_latents)
 
+        s2_guiding_tokens, s2_guiding_positions = None, None
+        if stage2_end_image_latent is not None:
+            positions2 = create_position_grid(1, latent_frames, stage2_h, stage2_w)
+            s2_guiding_tokens, s2_guiding_positions = _prepare_guiding_tokens(
+                stage2_end_image_latent, positions2, latent_frames, stage2_h, stage2_w
+            )
+
         # Joint video + audio refinement (no CFG, positive embeddings only)
         latents, audio_latents = denoise_distilled(
             latents,
@@ -2696,6 +2806,9 @@ def generate_video(
             audio_positions=audio_positions,
             audio_embeddings=audio_embeddings_pos,
             audio_frozen=is_a2v,
+            guiding_tokens=s2_guiding_tokens,
+            guiding_positions=s2_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
     elif pipeline == PipelineType.DEV_TWO_STAGE_HQ:
@@ -2836,6 +2949,12 @@ def generate_video(
             latents = mx.random.normal(stage1_shape, dtype=model_dtype)
             mx.eval(latents)
 
+        hq_s1_guiding_tokens, hq_s1_guiding_positions = None, None
+        if stage1_end_image_latent is not None:
+            hq_s1_guiding_tokens, hq_s1_guiding_positions = _prepare_guiding_tokens(
+                stage1_end_image_latent, positions, latent_frames, stage1_h, stage1_w
+            )
+
         # Stage 1: res_2s with CFG (STG disabled for HQ by default)
         latents, audio_latents = denoise_res2s_av(
             latents,
@@ -2860,6 +2979,9 @@ def generate_video(
             modality_scale=modality_scale,
             noise_seed=seed,
             audio_frozen=is_a2v,
+            guiding_tokens=hq_s1_guiding_tokens,
+            guiding_positions=hq_s1_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
         mx.eval(audio_latents)
@@ -2947,6 +3069,13 @@ def generate_video(
             )
             mx.eval(audio_latents)
 
+        hq_s2_guiding_tokens, hq_s2_guiding_positions = None, None
+        if stage2_end_image_latent is not None:
+            hq_positions2 = create_position_grid(1, latent_frames, stage2_h, stage2_w)
+            hq_s2_guiding_tokens, hq_s2_guiding_positions = _prepare_guiding_tokens(
+                stage2_end_image_latent, hq_positions2, latent_frames, stage2_h, stage2_w
+            )
+
         # Stage 2: res_2s with no CFG (positive embeddings only)
         stage2_sigmas = mx.array(STAGE_2_SIGMAS, dtype=mx.float32)
         latents, audio_latents = denoise_res2s_av(
@@ -2967,6 +3096,9 @@ def generate_video(
             video_state=state2,
             noise_seed=seed + 1,
             audio_frozen=is_a2v,
+            guiding_tokens=hq_s2_guiding_tokens,
+            guiding_positions=hq_s2_guiding_positions,
+            guiding_strength=end_image_strength,
         )
 
     del transformer

--- a/mlx_video/models/ltx_2/video_vae/sampling.py
+++ b/mlx_video/models/ltx_2/video_vae/sampling.py
@@ -90,10 +90,15 @@ class SpaceToDepthDownsample(nn.Module):
 
         # Skip connection: space-to-depth on input, then group mean
         x_in = self._space_to_depth(x)
-        # Reshape for group mean: (b, c*prod(stride), d, h, w) -> (b, out_channels, group_size, d, h, w)
+        # Derive actual out_channels from the conv weight to handle config/weight mismatches
+        # (e.g. LTX-2.3 weights have different channel counts than the config implies)
+        st, sh, sw = self.stride
+        actual_conv_out = self.conv.conv.weight.shape[0]
+        actual_out_channels = actual_conv_out * st * sh * sw
         b2, c2, d2, h2, w2 = x_in.shape
-        x_in = mx.reshape(x_in, (b2, self.out_channels, self.group_size, d2, h2, w2))
-        x_in = mx.mean(x_in, axis=2)  # (b, out_channels, d, h, w)
+        actual_group_size = c2 // actual_out_channels
+        x_in = mx.reshape(x_in, (b2, actual_out_channels, actual_group_size, d2, h2, w2))
+        x_in = mx.mean(x_in, axis=2)  # (b, actual_out_channels, d, h, w)
 
         # Conv branch: apply conv then space-to-depth
         x_conv = self.conv(x, causal=causal)


### PR DESCRIPTION
## Summary

- Replaces the previous hard-token-replacement approach for end-frame I2V conditioning with the **guiding-token appending** mechanism used by LTX-2's own `VideoConditionByKeyframeIndex`
- The conditioning latent is flattened into tokens and appended to the video sequence before each transformer pass; the model attends to the target end frame as a clean reference without overwriting any video token, avoiding abrupt appearance jumps
- Extended to all four pipelines: `DISTILLED`, `DEV`, `DEV_TWO_STAGE`, `DEV_TWO_STAGE_HQ`
- Also fixes a `SpaceToDepthDownsample` broadcast error in the VAE encoder that appeared with LTX-2.3 weights (config declares `out_channels=1024` but actual weights are `2048`; the fix reads the channel count from the weight tensor at runtime)

## Technical approach

For each denoiser call:
1. The end-image latent is encoded once and flattened to `(1, h*w, C)` tokens
2. The positions of the last latent frame are extracted from the video position grid and used as the guiding token positions
3. Inside the denoising loop: `[video_tokens, guiding_tokens]` are concatenated on the sequence axis; guiding tokens receive `cond_ts = sigma × (1 − guiding_strength)` (equivalent to `denoise_mask = 1 − strength` in the PyTorch reference)
4. After the transformer forward pass, only `velocity[:, :num_video_tokens, :]` is used — guiding token outputs are discarded
5. For denoisers that pre-compute RoPE (`denoise_dev_av`, `denoise_res2s_av`), the extended position grid covering both video and guiding tokens is passed to `precompute_freqs_cis` once before the loop

## Testing status

⚠️ **Tested on `DISTILLED` pipeline only** (LTX-2.3 distilled, `prince-canuma/LTX-2.3-distilled`).

The `DEV`, `DEV_TWO_STAGE`, and `DEV_TWO_STAGE_HQ` pipelines follow the same token-appending logic and have been reviewed for correctness, but have **not been run end-to-end** — the base (non-distilled) LTX-2.3 model weights are several GB and were not locally available during development. Community testing on those pipelines is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)