### PR TITLE
fix(wan2.1): causal VAE decode — T latents must yield 1+(T−1)·4 frames, not 4·T

### DIFF
--- a/mlx_video/models/wan_2/vae.py
+++ b/mlx_video/models/wan_2/vae.py
@@ -282,11 +282,42 @@ class Resample(nn.Module):
         b, c, t, h, w = x.shape
 
         if self.mode == "upsample3d":
-            # Temporal upsample via learned conv
-            x_t = self.time_conv(x)  # [B, 2C, T, H, W]
-            x_t = x_t.reshape(b, 2, c, t, h, w)
-            x = mx.stack([x_t[:, 0], x_t[:, 1]], axis=3).reshape(b, c, t * 2, h, w)
-            t = t * 2
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    # First chunk: 'Rep' sentinel — skip time_conv so the
+                    # first latent frame is not temporally doubled (reference
+                    # Wan2.1 causal mapping: T latents -> 1 + (T-1)*4 frames)
+                    feat_cache[idx] = "Rep"
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -CACHE_T:]
+                    was_rep = isinstance(feat_cache[idx], str)
+                    if cache_x.shape[2] < 2 and not was_rep:
+                        cache_x = mx.concatenate(
+                            [feat_cache[idx][:, :, -1:], cache_x], axis=2
+                        )
+                    elif cache_x.shape[2] < 2 and was_rep:
+                        cache_x = mx.concatenate(
+                            [mx.zeros_like(cache_x), cache_x], axis=2
+                        )
+                    if was_rep:
+                        x_t = self.time_conv(x)
+                    else:
+                        x_t = self.time_conv(x, cache_x=feat_cache[idx])
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+                    x_t = x_t.reshape(b, 2, c, t, h, w)
+                    x = mx.stack([x_t[:, 0], x_t[:, 1]], axis=3).reshape(
+                        b, c, t * 2, h, w
+                    )
+                    t = t * 2
+            else:
+                # Temporal upsample via learned conv
+                x_t = self.time_conv(x)  # [B, 2C, T, H, W]
+                x_t = x_t.reshape(b, 2, c, t, h, w)
+                x = mx.stack([x_t[:, 0], x_t[:, 1]], axis=3).reshape(b, c, t * 2, h, w)
+                t = t * 2
 
         if self.mode.startswith("upsample"):
             # Per-frame spatial upsample: nearest 2x + Conv2d
@@ -375,18 +406,45 @@ class Decoder3d(nn.Module):
             CausalConv3d(dims[-1], 3, 3, padding=1),  # [2]
         ]
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(self, x: mx.array, feat_cache=None, feat_idx=None) -> mx.array:
         """x: [B, z_dim, T, H, W] -> [B, 3, T_out, H_out, W_out]"""
-        x = self.conv1(x)
+        if feat_cache is not None:
+            # conv1 with caching
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:]
+            if cache_x.shape[2] < CACHE_T and feat_cache[idx] is not None:
+                cache_x = mx.concatenate([feat_cache[idx][:, :, -1:], cache_x], axis=2)
+            x = self.conv1(x, cache_x=feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
 
         for layer in self.middle:
-            x = layer(x)
+            if feat_cache is not None and isinstance(layer, ResidualBlock):
+                x = layer(x, feat_cache=feat_cache, feat_idx=feat_idx)
+            else:
+                x = layer(x)
 
         for layer in self.upsamples:
-            x = layer(x)
+            if feat_cache is not None and isinstance(layer, (ResidualBlock, Resample)):
+                x = layer(x, feat_cache=feat_cache, feat_idx=feat_idx)
+            else:
+                x = layer(x)
 
-        x = nn.silu(self.head[0](x))
-        x = self.head[2](x)
+        if feat_cache is not None:
+            # Head: norm -> silu -> [cache] -> conv
+            x = nn.silu(self.head[0](x))
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:]
+            if cache_x.shape[2] < CACHE_T and feat_cache[idx] is not None:
+                cache_x = mx.concatenate([feat_cache[idx][:, :, -1:], cache_x], axis=2)
+            x = self.head[2](x, cache_x=feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = nn.silu(self.head[0](x))
+            x = self.head[2](x)
         return x
 
 
@@ -559,21 +617,47 @@ class WanVAE(nn.Module):
         return count
 
     def decode(self, z: mx.array) -> mx.array:
-        """Decode latent to video.
+        """Decode latent to video using chunked decoding.
+
+        Decodes one latent frame at a time with temporal feature caching to
+        match reference behavior: T latent frames produce 1 + (T-1)*4 output
+        frames (the first latent frame is not temporally upsampled). Memory
+        stays flat in T.
 
         Args:
             z: Normalized latent [B, z_dim, T, H, W]
 
         Returns:
-            Video [B, 3, T_out, H_out, W_out] clamped to [-1, 1]
+            Video [B, 3, 1 + (T-1)*4, H_out, W_out] clamped to [-1, 1]
         """
         mean = self.mean.reshape(1, -1, 1, 1, 1)
         inv_std = self.inv_std.reshape(1, -1, 1, 1, 1)
         z = z / inv_std + mean
 
         x = self.conv2(z)
-        out = self.decoder(x)
+
+        num_slots = self._count_decoder_cache_slots()
+        feat_cache = [None] * num_slots
+        out = None
+        for i in range(x.shape[2]):
+            feat_idx = [0]
+            chunk = self.decoder(x[:, :, i : i + 1], feat_cache=feat_cache, feat_idx=feat_idx)
+            out = chunk if out is None else mx.concatenate([out, chunk], axis=2)
         return mx.clip(out, -1, 1)
+
+    def _count_decoder_cache_slots(self) -> int:
+        """Count CausalConv3d that participate in chunked decoding cache."""
+        count = 1  # decoder.conv1
+        for layer in self.decoder.middle:
+            if isinstance(layer, ResidualBlock):
+                count += 2
+        for layer in self.decoder.upsamples:
+            if isinstance(layer, ResidualBlock):
+                count += 2
+            elif isinstance(layer, Resample) and layer.mode == "upsample3d":
+                count += 1  # time_conv
+        count += 1  # decoder.head CausalConv3d
+        return count
 
     def decode_tiled(self, z: mx.array, tiling_config=None) -> mx.array:
         """Decode latent to video using tiling to reduce memory usage.
@@ -616,7 +700,14 @@ class WanVAE(nn.Module):
 
         def tile_decode(tile_latents, **kwargs):
             x = self.conv2(tile_latents)
-            out = self.decoder(x)
+            feat_cache = [None] * self._count_decoder_cache_slots()
+            out = None
+            for i in range(x.shape[2]):
+                feat_idx = [0]
+                chunk = self.decoder(
+                    x[:, :, i : i + 1], feat_cache=feat_cache, feat_idx=feat_idx
+                )
+                out = chunk if out is None else mx.concatenate([out, chunk], axis=2)
             return mx.clip(out, -1, 1)
 
         return decode_with_tiling(
@@ -625,5 +716,5 @@ class WanVAE(nn.Module):
             tiling_config=tiling_config,
             spatial_scale=8,  # 3× spatial 2× upsamples = 8×
             temporal_scale=4,  # 2× temporal upsamples × 2 = 4×
-            causal_temporal=False,  # Wan2.1 uses non-causal temporal (T → 4T)
+            causal_temporal=True,  # Wan2.1 causal mapping: T -> 1 + (T-1)*4
         )

--- a/tests/test_wan_vae.py
+++ b/tests/test_wan_vae.py
@@ -123,6 +123,36 @@ class TestWanVAE:
         assert len(VAE_STD) == 16
         assert all(s > 0 for s in VAE_STD)
 
+    def test_decode_causal_frame_count(self):
+        """Reference Wan2.1 mapping: T latent frames -> 1 + (T-1)*4 output
+        frames. The first latent frame is NOT temporally upsampled (the
+        'Rep' first-chunk sentinel skips time_conv in upsample3d)."""
+        import mlx.core as mx
+
+        from mlx_video.models.wan_2.vae import WanVAE
+
+        vae = WanVAE(z_dim=16)
+        for t_lat, t_out in [(1, 1), (2, 5), (5, 17)]:
+            z = mx.random.normal((1, 16, t_lat, 4, 4))
+            out = vae.decode(z)
+            assert out.shape == (1, 3, t_out, 32, 32), (
+                f"T={t_lat}: expected {t_out} frames, got {out.shape[2]}"
+            )
+
+    def test_decode_roundtrip_frame_count(self):
+        """encode(x) then decode should reproduce the input frame count for
+        the canonical 4k+1 frame videos."""
+        import mlx.core as mx
+
+        from mlx_video.models.wan_2.vae import WanVAE
+
+        vae = WanVAE(z_dim=16, encoder=True)
+        x = mx.random.normal((1, 3, 9, 32, 32))
+        z = vae.encode(x)
+        assert z.shape[2] == 3  # 1 + (9-1)/4
+        out = vae.decode(z)
+        assert out.shape[2] == 9
+
 
 # ---------------------------------------------------------------------------
 # Wan2.2 VAE Component Tests


### PR DESCRIPTION
## Bug

`WanVAE.decode` (wan_2) runs `Decoder3d` over the whole latent sequence, and the `upsample3d` path temporally doubles **every** frame — so `T` latent frames decode to `4·T` output frames. The reference Wan2.1 decoder ([Wan-AI/Wan2.1 `vae.py`](https://github.com/Wan-Video/Wan2.1/blob/main/wan/modules/vae.py), also diffusers `AutoencoderKLWan`) decodes causally one latent frame at a time: the first chunk sets the `'Rep'` sentinel and **skips `time_conv`**, so the first latent frame is not temporally upsampled — `T → 1 + (T−1)·4` frames (65 for 17 latents, not 68).

Beyond the wrong frame count, the whole-sequence path produces **different pixels at the start**: comparing against the reference decoder on identical latents, boundary frames differ by up to 0.21 (abs, in [-1,1] range), decaying over ~8 frames, with a +3-frame phase shift across the rest (~190 ms at 16 fps — breaks A/V sync for downstream use).

Interestingly `tiling.py` already documents both mappings and has `causal_temporal` support — `decode_tiled` just passes `causal_temporal=False` for Wan2.1, which contradicts the reference.

## Fix

Mirrors the existing **encode** path (which already does cached chunked processing correctly):

- `Resample`: cached `upsample3d` branch with the `'Rep'` first-chunk sentinel, structured like the existing cached `downsample3d` branch
- `Decoder3d.__call__`: accepts `feat_cache`/`feat_idx` (mirror of `Encoder3d`)
- `WanVAE.decode`: per-latent-frame chunked decode + `_count_decoder_cache_slots` (mirror of `_count_encoder_cache_slots`); peak memory is now **flat in T** as a side effect
- `decode_tiled`: per-tile chunked decode, `causal_temporal=True`
- tests: frame-count (`T=1→1, 2→5, 5→17`) and encode/decode roundtrip

Whole-sequence behavior is preserved when `feat_cache=None` is passed to the decoder directly.

## Verification

Against the reference PyTorch Wan2.1 VAE (`Wan2.1_VAE.pth`, fp32, CPU), identical latents:

| T latents | ref frames | before | after | max_abs vs ref |
|---|---|---|---|---|
| 1 | 1 | 4 | 1 | 2.6e-6 |
| 5 | 17 | 20 | 17 | 6.3e-6 |

`tests/` pass (`test_wan_vae.py` 80/80 including the new cases; full suite 387 passed — the one failure, `test_wan_tiling.py::TestNonCausalTemporal::test_causal_vs_noncausal_output_size`, fails identically on current `main` and is unrelated).

Found while porting SCAIL-2 (Wan2.1-I2V fork) on top of the wan_2 substrate — happy to adjust scope/style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)