### PR TITLE
fix(ltx_2): use LTXModelConfig.from_dict to filter unknown config keys

### DIFF
--- a/mlx_video/models/ltx_2/ltx_2.py
+++ b/mlx_video/models/ltx_2/ltx_2.py
@@ -670,7 +670,7 @@ class LTXModel(nn.Module):
         config_dict = {}
         with open(model_path / "config.json", "r") as f:
             config_dict = json.load(f)
-        config = LTXModelConfig(**config_dict)
+        config = LTXModelConfig.from_dict(config_dict)
         model = cls(config)
 
         weights = {}


### PR DESCRIPTION
## Summary
- `LTXModel.from_pretrained()` constructs the config with `LTXModelConfig(**config_dict)`, which crashes on a `TypeError` whenever the downloaded `config.json` includes extra diffusers metadata fields (e.g. `_class_name`, `_diffusers_version`). I hit this loading both `Lightricks/LTX-2` and `prince-canuma/LTX-2-distilled`.
- `BaseModelConfig.from_dict()` already exists specifically to filter a dict down to valid constructor params, but `from_pretrained()` wasn't using it. Swapping the direct constructor call for `.from_dict()` fixes the crash with no behavior change for already-clean config dicts.

## Test plan
- Reproduced the crash on a clean clone loading both `Lightricks/LTX-2` and `prince-canuma/LTX-2-distilled` checkpoints.
- Applied the one-line fix and successfully ran `python -m mlx_video.models.ltx_2.generate` end-to-end on Apple Silicon (M-series, MLX/Metal device), producing a valid output video.