### PR TITLE
feat(wan2.2): memory_mode=relay — run A14B bf16 on 48GB (one expert resident at a time)

### DIFF
--- a/mlx_video/models/wan_2/generate.py
+++ b/mlx_video/models/wan_2/generate.py
@@ -10,12 +10,13 @@ runnable in bf16 on 48GB unified memory (measured 36.8GB at 832x480x81f,
 once per generation. memory_mode="parallel" restores both-resident behavior.
 
 Relay changes only WHEN weights are resident, never the math: with the same
-seed relay and parallel produce bit-identical latents (contract-tested via
-dump_latents + MD5). To make that guarantee structural, the initial noise is
-drawn BEFORE any transformer weight loading, so the sample cannot depend on
-how many PRNG draws model construction consumes. NOTE: this changes
-same-seed outputs relative to earlier versions (which drew the noise after
-building both experts).
+seed, relay and parallel produce bit-identical latents (contract-tested via
+dump_latents + MD5), and parallel is bit-identical with previous releases —
+relay pre-consumes the construction-time PRNG draws with discarded lazy
+replicas of the loader path, so the initial noise lands on the same stream
+position in every mode. (Known exception: quantized + LoRA in relay mode is
+deterministic but not seed-identical to parallel — the LoRA dequant-merge
+constructs extra layers whose PRNG use depends on the LoRA configs.)
 """
 
 import argparse
@@ -349,15 +350,6 @@ def generate_video(
     w_latent = width // vae_stride[2]
     target_shape = (z_dim, t_latent, h_latent, w_latent)
 
-    # Draw the initial noise HERE, before any weight loading (deliberate
-    # deviation from stock, which draws it after building both experts).
-    # Model construction consumes the global PRNG stream by an amount that
-    # depends on loader internals (layer inits, QuantizedLinear constructors
-    # inside nn.quantize, ...): drawing first makes the sample independent of
-    # all of it, which is what guarantees relay == parallel bit-identically.
-    # Same-seed outputs therefore differ from stock's by design.
-    noise = mx.random.normal(target_shape)
-    mx.eval(noise)
 
     # Sequence length for transformer
     seq_len = math.ceil(
@@ -562,12 +554,36 @@ def generate_video(
             if mode == "parallel":
                 self.bundles["low"] = _build_expert("low")
                 self.bundles["high"] = _build_expert("high")
-            # relay: nothing to pre-consume — the initial noise is drawn
-            # BEFORE any construction (see the draw next to target_shape), so
-            # PRNG consumption during builds cannot influence the sample.
-            # (Draw-counting equalization is not viable: construction draws
-            # depend on loader internals, e.g. nn.quantize's QuantizedLinear
-            # constructors consume extra RNG.)
+            else:
+                # PRNG parity with stock/parallel: model construction consumes
+                # the global PRNG stream (keyless layer inits AND the
+                # QuantizedLinear constructors inside nn.quantize), and stock
+                # builds BOTH experts between mx.random.seed() and the initial
+                # noise draw. Relay defers the real builds, so pre-consume the
+                # stream with two discarded LAZY replicas of the loader's
+                # construction path (arrays are never evaluated — near-zero
+                # cost). Verified: replica consumption == real-loader
+                # consumption, so the noise (and every output) is bit-exact
+                # with parallel AND with previous releases for the same seed.
+                # Known exception: quantized models + LoRA (the dequant-merge
+                # path constructs additional Linears whose RNG use depends on
+                # the LoRA configs) — relay stays deterministic per-mode there
+                # but same-seed output differs from parallel.
+                import mlx.nn as _nn
+
+                from mlx_video.models.wan_2.convert import _quantize_predicate
+                from mlx_video.models.wan_2.wan_2 import WanModel as _WM
+
+                for _ in ("low", "high"):
+                    _replica = _WM(config)
+                    if quantization:
+                        _nn.quantize(
+                            _replica,
+                            group_size=quantization["group_size"],
+                            bits=quantization["bits"],
+                            class_predicate=lambda p, m: _quantize_predicate(p, m),
+                        )
+                    del _replica
 
         def get(self, timestep_val):
             which = "high" if timestep_val >= boundary else "low"
@@ -623,8 +639,11 @@ def generate_video(
     sched = sched_cls(num_train_timesteps=config.num_train_timesteps)
     sched.set_timesteps(steps, shift=shift)
 
-    # (initial noise already drawn right after target_shape, before any
-    # weight loading — see the PRNG-independence note there)
+    # Generate initial noise — at the SAME stream position as previous
+    # versions (after both experts' construction-time PRNG consumption):
+    # parallel mode is bit-exact with prior releases, and relay pre-consumed
+    # an identical amount via lazy replicas (see _PhaseProvider.__init__).
+    noise = mx.random.normal(target_shape)
 
     # I2V initialization: TI2V-5B blends image with noise, I2V-14B uses pure noise
     if is_i2v_mask_blend:

--- a/mlx_video/models/wan_2/generate.py
+++ b/mlx_video/models/wan_2/generate.py
@@ -698,7 +698,13 @@ def generate_video(
             )
         print()
 
-    # Free transformer models and text embeddings
+    # Free transformer models and text embeddings.
+    # The loop locals must be cleared too: `_call` is the mx.compile wrapper
+    # and holds the model through its traced graph (whose constants are the
+    # weight buffers), and `rcs`/`ctx` alias per-model tensors. Without this,
+    # the last-used transformer (~14-28GB for A14B) stays resident through the
+    # whole VAE decode and gc.collect()+mx.clear_cache() below free nothing.
+    model = kv = rcs = _call = ctx = None
     if is_dual:
         del low_noise_model, high_noise_model, cross_kv_low, cross_kv_high
         if cfg_disabled:
@@ -707,11 +713,12 @@ def generate_video(
             del context_cfg_low, context_cfg_high
     else:
         del single_model, cross_kv
+        rope_cos_sin = None
         if cfg_disabled:
             del context_cond
         else:
             del context_cfg
-    del model, kv, context
+    del context
     if context_null is not None:
         del context_null
     gc.collect()

--- a/mlx_video/models/wan_2/generate.py
+++ b/mlx_video/models/wan_2/generate.py
@@ -1,4 +1,22 @@
-"""Wan2.2 Text-to-Video generation pipeline for MLX."""
+"""Wan2.2 Text-to-Video generation pipeline for MLX.
+
+Dual-expert (A14B) memory modes: the two experts switch ONCE at a
+deterministic timestep boundary (high-noise phase, then low-noise phase).
+memory_mode="relay" (the default for dual models) keeps only the ACTIVE
+expert resident — build high, run the high phase, free it at the boundary,
+build low. Peak memory ~ one expert instead of two, which makes the A14B
+runnable in bf16 on 48GB unified memory (measured 36.8GB at 832x480x81f,
+44.3GB with CFG). Cost: one extra weight load from disk at the boundary,
+once per generation. memory_mode="parallel" restores both-resident behavior.
+
+Relay changes only WHEN weights are resident, never the math: with the same
+seed relay and parallel produce bit-identical latents (contract-tested via
+dump_latents + MD5). To make that guarantee structural, the initial noise is
+drawn BEFORE any transformer weight loading, so the sample cannot depend on
+how many PRNG draws model construction consumes. NOTE: this changes
+same-seed outputs relative to earlier versions (which drew the noise after
+building both experts).
+"""
 
 import argparse
 import gc
@@ -85,6 +103,8 @@ def generate_video(
     no_compile: bool = False,
     trim_first_frames: int = 0,
     debug_latents: bool = False,
+    memory_mode: str = "auto",
+    dump_latents: str | None = None,
 ):
     """Generate video using Wan pipeline (supports T2V and I2V).
 
@@ -118,6 +138,12 @@ def generate_video(
             discards first 4). Use 2 for more aggressive trimming. Default: 0.
         debug_latents: If True, print per-temporal-position latent statistics
             after denoising for diagnosing first-frame artifacts.
+        memory_mode: Expert residency for dual models. "parallel" = stock
+            behavior (both experts resident). "relay" = only the active expert
+            resident, freed/loaded at the phase boundary. "auto" = relay for
+            dual models, no-op for single. Ignored for single models.
+        dump_latents: Optional path; save the final pre-VAE latents as .npy
+            (float32) for bitwise relay-vs-parallel contract testing.
     """
     import json
 
@@ -127,6 +153,13 @@ def generate_video(
         FlowMatchEulerScheduler,
         FlowUniPCScheduler,
     )
+
+    # Fail fast on typos: a silently-unknown mode would neither prebuild nor
+    # free experts, degenerating into both-resident with no warning.
+    if memory_mode not in ("auto", "relay", "parallel"):
+        raise ValueError(
+            f"memory_mode must be 'auto', 'relay' or 'parallel', got {memory_mode!r}"
+        )
 
     model_dir = Path(model_dir)
 
@@ -316,6 +349,16 @@ def generate_video(
     w_latent = width // vae_stride[2]
     target_shape = (z_dim, t_latent, h_latent, w_latent)
 
+    # Draw the initial noise HERE, before any weight loading (deliberate
+    # deviation from stock, which draws it after building both experts).
+    # Model construction consumes the global PRNG stream by an amount that
+    # depends on loader internals (layer inits, QuantizedLinear constructors
+    # inside nn.quantize, ...): drawing first makes the sample independent of
+    # all of it, which is what guarantees relay == parallel bit-identically.
+    # Same-seed outputs therefore differ from stock's by design.
+    noise = mx.random.normal(target_shape)
+    mx.eval(noise)
+
     # Sequence length for transformer
     seq_len = math.ceil(
         (h_latent * w_latent) / (patch_size[1] * patch_size[2]) * t_latent
@@ -451,70 +494,7 @@ def generate_video(
     _loras_high = (loras or []) + (loras_high or []) or None
     _loras_single = loras
 
-    if is_dual:
-        low_noise_path = model_dir / "low_noise_model.safetensors"
-        high_noise_path = model_dir / "high_noise_model.safetensors"
-        low_noise_model = load_wan_model(
-            low_noise_path, config, quantization, loras=_loras_low
-        )
-        high_noise_model = load_wan_model(
-            high_noise_path, config, quantization, loras=_loras_high
-        )
-    else:
-        single_model = load_wan_model(
-            model_dir / "model.safetensors", config, quantization, loras=_loras_single
-        )
-    print(f"{Colors.DIM}  Models loaded: {time.time() - t2:.1f}s{Colors.RESET}")
-
-    # Precompute text embeddings once (avoids redundant MLP in every step)
-    # Each model has its own text_embedding weights, so dual models need separate embeddings
-    if cfg_disabled:
-        # No CFG: only compute cond embeddings (B=1 forward pass, 2x faster)
-        if is_dual:
-            context_emb_low = low_noise_model.embed_text([context])
-            context_emb_high = high_noise_model.embed_text([context])
-            mx.eval(context_emb_low, context_emb_high)
-            context_cond_low = context_emb_low[0:1]
-            context_cond_high = context_emb_high[0:1]
-        else:
-            context_emb = single_model.embed_text([context])
-            mx.eval(context_emb)
-            context_cond = context_emb[0:1]
-    else:
-        if is_dual:
-            context_emb_low = low_noise_model.embed_text([context, context_null])
-            context_emb_high = high_noise_model.embed_text([context, context_null])
-            mx.eval(context_emb_low, context_emb_high)
-            context_cfg_low = mx.concatenate(
-                [context_emb_low[0:1], context_emb_low[1:2]], axis=0
-            )
-            context_cfg_high = mx.concatenate(
-                [context_emb_high[0:1], context_emb_high[1:2]], axis=0
-            )
-        else:
-            context_emb = single_model.embed_text([context, context_null])
-            mx.eval(context_emb)
-            context_cfg = mx.concatenate([context_emb[0:1], context_emb[1:2]], axis=0)
-
-    # Precompute cross-attention K/V caches (constant across all steps)
-    if cfg_disabled:
-        if is_dual:
-            cross_kv_low = low_noise_model.prepare_cross_kv(context_cond_low)
-            cross_kv_high = high_noise_model.prepare_cross_kv(context_cond_high)
-            mx.eval(cross_kv_low, cross_kv_high)
-        else:
-            cross_kv = single_model.prepare_cross_kv(context_cond)
-            mx.eval(cross_kv)
-    else:
-        if is_dual:
-            cross_kv_low = low_noise_model.prepare_cross_kv(context_cfg_low)
-            cross_kv_high = high_noise_model.prepare_cross_kv(context_cfg_high)
-            mx.eval(cross_kv_low, cross_kv_high)
-        else:
-            cross_kv = single_model.prepare_cross_kv(context_cfg)
-            mx.eval(cross_kv)
-
-    # Precompute RoPE frequencies (grid sizes are constant across all steps)
+    # RoPE grid sizes are constant across all steps and independent of the model
     f_grid = t_latent // patch_size[0]
     h_grid = h_latent // patch_size[1]
     w_grid = w_latent // patch_size[2]
@@ -522,13 +502,116 @@ def generate_video(
         rope_grid_sizes = [(f_grid, h_grid, w_grid)]
     else:
         rope_grid_sizes = [(f_grid, h_grid, w_grid), (f_grid, h_grid, w_grid)]
+
+    if memory_mode == "auto":
+        memory_mode = "relay" if is_dual else "parallel"
+    if memory_mode not in ("relay", "parallel"):
+        raise ValueError(
+            f"memory_mode must be 'relay', 'parallel' or 'auto', got {memory_mode!r}"
+        )
+
+    def _build_expert(which, restore_rng=False):
+        """Load one expert and its per-model precomputes (text embedding,
+        cross-attn K/V, RoPE tables). Everything the denoise loop needs from
+        a resident expert lives in the returned bundle; freeing the bundle
+        frees the expert."""
+        path = model_dir / f"{which}_noise_model.safetensors"
+        loras_w = _loras_high if which == "high" else _loras_low
+        tb = time.time()
+        # restore_rng=True ONLY for deferred (in-loop) relay builds: those
+        # must not perturb the global PRNG stream. The provider-init builds in
+        # parallel mode must consume the stream normally so parallel keeps the
+        # historical construction-order behavior.
+        _saved_rng = None
+        if restore_rng:
+            try:
+                _saved_rng = mx.random.state[0]
+            except Exception:
+                pass
+        m = load_wan_model(path, config, quantization, loras=loras_w)
+        if _saved_rng is not None:
+            mx.random.state[0] = _saved_rng
+        if cfg_disabled:
+            emb = m.embed_text([context])
+            mx.eval(emb)
+            ctx = emb[0:1]
+        else:
+            emb = m.embed_text([context, context_null])
+            mx.eval(emb)
+            ctx = mx.concatenate([emb[0:1], emb[1:2]], axis=0)
+        kv = m.prepare_cross_kv(ctx)
+        rcs = m.prepare_rope(rope_grid_sizes)
+        mx.eval(ctx, kv, rcs)
+        if not no_compile:
+            m._compiled = mx.compile(m)
+        print(
+            f"{Colors.DIM}  [{memory_mode}] {which}-noise expert ready: "
+            f"{time.time() - tb:.1f}s{Colors.RESET}"
+        )
+        return {"model": m, "ctx": ctx, "kv": kv, "rcs": rcs}
+
+    class _PhaseProvider:
+        """Hands the denoise loop the bundle for the expert active at a given
+        timestep. parallel = both resident (stock behavior); relay = only the
+        active one, with a free+load at each phase change. The math is
+        identical in both modes — only weight residency differs."""
+
+        def __init__(self, mode):
+            self.mode = mode
+            self.bundles = {}
+            if mode == "parallel":
+                self.bundles["low"] = _build_expert("low")
+                self.bundles["high"] = _build_expert("high")
+            # relay: nothing to pre-consume — the initial noise is drawn
+            # BEFORE any construction (see the draw next to target_shape), so
+            # PRNG consumption during builds cannot influence the sample.
+            # (Draw-counting equalization is not viable: construction draws
+            # depend on loader internals, e.g. nn.quantize's QuantizedLinear
+            # constructors consume extra RNG.)
+
+        def get(self, timestep_val):
+            which = "high" if timestep_val >= boundary else "low"
+            if which not in self.bundles:
+                if self.mode == "relay":
+                    self._free_all()
+                self.bundles[which] = _build_expert(which, restore_rng=True)
+            return self.bundles[which]
+
+        def _free_all(self):
+            for b in list(self.bundles.values()):
+                b.clear()
+            self.bundles.clear()
+            gc.collect()
+            mx.clear_cache()
+
+        def close(self):
+            self._free_all()
+
+    # Boundary for model switching (dual model only) — parity-critical constant,
+    # single definition point (used by provider.get AND guide_scale selection)
+    boundary = (config.boundary * config.num_train_timesteps) if is_dual else None
+
+    provider = None
     if is_dual:
-        rope_cos_sin_low = low_noise_model.prepare_rope(rope_grid_sizes)
-        rope_cos_sin_high = high_noise_model.prepare_rope(rope_grid_sizes)
-        mx.eval(rope_cos_sin_low, rope_cos_sin_high)
+        provider = _PhaseProvider(memory_mode)
     else:
+        single_model = load_wan_model(
+            model_dir / "model.safetensors", config, quantization, loras=_loras_single
+        )
+        if cfg_disabled:
+            context_emb = single_model.embed_text([context])
+            mx.eval(context_emb)
+            context_cond = context_emb[0:1]
+            cross_kv = single_model.prepare_cross_kv(context_cond)
+        else:
+            context_emb = single_model.embed_text([context, context_null])
+            mx.eval(context_emb)
+            context_cfg = mx.concatenate([context_emb[0:1], context_emb[1:2]], axis=0)
+            cross_kv = single_model.prepare_cross_kv(context_cfg)
+        mx.eval(cross_kv)
         rope_cos_sin = single_model.prepare_rope(rope_grid_sizes)
         mx.eval(rope_cos_sin)
+    print(f"{Colors.DIM}  Models loaded: {time.time() - t2:.1f}s{Colors.RESET}")
 
     # Setup scheduler
     _schedulers = {
@@ -540,8 +623,8 @@ def generate_video(
     sched = sched_cls(num_train_timesteps=config.num_train_timesteps)
     sched.set_timesteps(steps, shift=shift)
 
-    # Generate initial noise
-    noise = mx.random.normal(target_shape)
+    # (initial noise already drawn right after target_shape, before any
+    # weight loading — see the PRNG-independence note there)
 
     # I2V initialization: TI2V-5B blends image with noise, I2V-14B uses pure noise
     if is_i2v_mask_blend:
@@ -549,20 +632,15 @@ def generate_video(
     else:
         latents = noise
 
-    # Boundary for model switching (dual model only)
-    boundary = (config.boundary * config.num_train_timesteps) if is_dual else None
-
     # Diffusion loop
     print(f"\n{Colors.GREEN}Denoising ({steps} steps)...{Colors.RESET}")
     t3 = time.time()
 
-    # Compile model forward for faster denoising
-    if not no_compile:
-        models_to_compile = (
-            [high_noise_model, low_noise_model] if is_dual else [single_model]
-        )
-        for m in models_to_compile:
-            m._compiled = mx.compile(m)
+    # Compile model forward for faster denoising.
+    # Dual experts are compiled inside _build_expert (relay mode may not have
+    # both resident here); only the single-model path is compiled at this point.
+    if not no_compile and not is_dual:
+        single_model._compiled = mx.compile(single_model)
 
     # Pre-convert timesteps to Python list to avoid .item() sync each step
     timestep_list = sched.timesteps.tolist()
@@ -572,14 +650,14 @@ def generate_video(
 
         # Select model, cached K/V, and precomputed RoPE
         if is_dual:
-            if timestep_val >= boundary:
-                model = high_noise_model
-                kv = cross_kv_high
-                rcs = rope_cos_sin_high
-            else:
-                model = low_noise_model
-                kv = cross_kv_low
-                rcs = rope_cos_sin_low
+            # Drop stale aliases BEFORE provider.get: at the phase boundary the
+            # previous iteration's locals would otherwise keep the outgoing
+            # expert alive through _free_all, defeating the relay (peak = both).
+            model = kv = rcs = _call = ctx = _bundle = None
+            _bundle = provider.get(timestep_val)
+            model = _bundle["model"]
+            kv = _bundle["kv"]
+            rcs = _bundle["rcs"]
         else:
             model = single_model
             kv = cross_kv
@@ -604,9 +682,7 @@ def generate_video(
             y_arg = [y_i2v] if is_i2v_channel_concat else None
 
             if is_dual:
-                ctx = (
-                    context_cond_high if timestep_val >= boundary else context_cond_low
-                )
+                ctx = _bundle["ctx"]
             else:
                 ctx = context_cond
             preds = _call(
@@ -644,11 +720,7 @@ def generate_video(
 
             y_arg = [y_i2v, y_i2v] if is_i2v_channel_concat else None
 
-            ctx = (
-                context_cfg
-                if not is_dual
-                else (context_cfg_high if timestep_val >= boundary else context_cfg_low)
-            )
+            ctx = context_cfg if not is_dual else _bundle["ctx"]
             preds = _call(
                 [latents, latents],
                 t=t_batch,
@@ -698,26 +770,28 @@ def generate_video(
             )
         print()
 
-    # Free transformer models and text embeddings.
-    # The loop locals must be cleared too: `_call` is the mx.compile wrapper
-    # and holds the model through its traced graph (whose constants are the
-    # weight buffers), and `rcs`/`ctx` alias per-model tensors. Without this,
-    # the last-used transformer (~14-28GB for A14B) stays resident through the
-    # whole VAE decode and gc.collect()+mx.clear_cache() below free nothing.
-    model = kv = rcs = _call = ctx = None
+    # Contract-test hook: final pre-VAE latents, before anything stochastic
+    # or lossy (VAE, mp4 encode) touches them
+    if dump_latents:
+        np.save(dump_latents, np.array(latents.astype(mx.float32)))
+        print(f"{Colors.DIM}  Latents dumped to {dump_latents}{Colors.RESET}")
+
+    # Free transformer models and text embeddings. Drop ALL loop aliases first:
+    # _call is the mx.compile wrapper and closes over the model (traced tape
+    # holds the weight buffers); rcs/ctx alias its tables. Missing any of these
+    # keeps the last expert resident through the whole VAE decode — stock has
+    # the same leak via the identical loop locals (upstream-fix candidate).
+    # None-assignment (not del) also survives the steps==0 edge case.
+    model = kv = rcs = _call = ctx = _bundle = None
     if is_dual:
-        del low_noise_model, high_noise_model, cross_kv_low, cross_kv_high
-        if cfg_disabled:
-            del context_cond_low, context_cond_high
-        else:
-            del context_cfg_low, context_cfg_high
+        provider.close()
     else:
         del single_model, cross_kv
-        rope_cos_sin = None
         if cfg_disabled:
             del context_cond
         else:
             del context_cfg
+        rope_cos_sin = None
     del context
     if context_null is not None:
         del context_null
@@ -937,6 +1011,23 @@ def main():
         action="store_true",
         help="Print per-temporal-position latent statistics after denoising (diagnostic)",
     )
+    parser.add_argument(
+        "--memory-mode",
+        type=str,
+        default="auto",
+        choices=["auto", "relay", "parallel"],
+        help="Dual-model expert residency: relay = only the active expert in "
+        "memory, swapped once at the phase boundary (fits A14B bf16 on 48GB); "
+        "parallel = both resident. auto (default) = relay for dual models",
+    )
+    parser.add_argument(
+        "--dump-latents",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Save the final pre-VAE latents as float32 .npy (for bitwise "
+        "relay-vs-parallel contract testing)",
+    )
     args = parser.parse_args()
 
     # Parse guide scale
@@ -977,6 +1068,8 @@ def main():
         no_compile=args.no_compile,
         trim_first_frames=args.trim_first_frames,
         debug_latents=args.debug_latents,
+        memory_mode=args.memory_mode,
+        dump_latents=args.dump_latents,
     )
 
 

--- a/regression_matrix.py
+++ b/regression_matrix.py
@@ -1,0 +1,128 @@
+"""Regression matrix for the wan22-relay-shedding branch (pre-PR gate).
+
+Small/fast runs (17f, few steps): we're hunting crashes, black clips and
+path regressions — quality evidence comes from the full-size probes in
+research/videogen. Every case runs the FORK code (this repo on sys.path).
+
+Cases:
+  1. 5B single-model, CFG            (single path was reorganized)
+  2. 5B T2V (no image), CFG          (t2v branch never exercised before)
+  3. Q4 dual + Lightning, parallel   (the app's historical path, LoRA merge)
+  4. Q4 dual + CFG, relay            (relay x quantized x CFG, 17f = alive zone)
+  5. bf16 dual relay, no_compile     (debug path)
+  6. Q4 dual + Lightning + trim_first_frames=1 (trim path)
+Then: pytest tests/test_wan_relay.py with WAN22_A14B_DIR=Q4 (bit-identity
+contract) and the weight-free suite.
+"""
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+FORK = Path(__file__).resolve().parent
+VB = Path.home() / "Documents/videoboom/local"
+PY = str(VB / ".venv/bin/python")
+MODELS = VB / "models"
+OUT = Path.home() / "Documents/research/videogen/artifacts/regression"
+KEY = Path.home() / "Documents/videoboom/.vbdata-test/E78FC29DE7B442EABC257FDD97/keyframes"
+LIGHT = (VB / ".lightning-dir").read_text().strip()
+
+PROMPT = "the man turns toward the camera in the rainy street, cinematic"
+IMG = str(KEY / "scene_8.png")
+
+CASES = [
+    dict(name="single_5b_cfg", model="Wan2.2-TI2V-5B-MLX", image=IMG,
+         frames=17, steps=6, guide="5.0"),
+    dict(name="t2v_5b_cfg", model="Wan2.2-TI2V-5B-MLX", image=None,
+         frames=17, steps=6, guide="5.0"),
+    dict(name="q4_lightning_parallel", model="Wan2.2-I2V-A14B-MLX-Q4", image=IMG,
+         frames=17, steps=4, guide="1", lora=True, memory_mode="parallel"),
+    dict(name="q4_cfg_relay", model="Wan2.2-I2V-A14B-MLX-Q4", image=IMG,
+         frames=17, steps=6, guide="3.5,3.5", memory_mode="relay"),
+    dict(name="bf16_relay_nocompile", model="Wan2.2-I2V-A14B-MLX-bf16", image=IMG,
+         frames=9, steps=2, guide="1", memory_mode="relay", no_compile=True),
+    dict(name="q4_lightning_trim", model="Wan2.2-I2V-A14B-MLX-Q4", image=IMG,
+         frames=13, steps=4, guide="1", lora=True, memory_mode="parallel",
+         trim=1),
+]
+
+RUNNER = r"""
+import json, sys, time
+sys.path.insert(0, "{fork}")
+import mlx.core as mx
+from mlx_video.models.wan_2.generate import generate_video
+c = json.loads(sys.argv[1])
+t0 = time.time()
+generate_video(
+    model_dir=c["model_dir"], prompt=c["prompt"], image=c.get("image"),
+    width=832, height=480, num_frames=c["frames"], steps=c["steps"],
+    guide_scale=c["guide"], seed=42, output_path=c["out"],
+    tiling="aggressive", loras_high=c.get("lh"), loras_low=c.get("ll"),
+    memory_mode=c.get("memory_mode", "auto"), no_compile=c.get("no_compile", False),
+    trim_first_frames=c.get("trim", 0),
+)
+print("RUN_OK", round(time.time()-t0, 1), round(mx.get_peak_memory()/1e9, 1))
+"""
+
+
+def luma(clip):
+    tmp = str(clip) + ".png"
+    subprocess.run(["ffmpeg", "-y", "-loglevel", "error", "-ss", "0.3",
+                    "-i", str(clip), "-frames:v", "1", tmp], timeout=60)
+    p = subprocess.run([PY, "-c",
+                        "import numpy as np, sys; from PIL import Image; "
+                        f"print(float(np.asarray(Image.open('{tmp}').convert('L')).mean()))"],
+                       capture_output=True, text=True, timeout=60)
+    return float(p.stdout.strip())
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    runner = OUT / "_runner.py"
+    runner.write_text(RUNNER.format(fork=FORK))
+    results = []
+    for c in CASES:
+        clip = OUT / f"{c['name']}.mp4"
+        cfg = dict(model_dir=str(MODELS / c["model"]), prompt=PROMPT,
+                   image=c.get("image"), frames=c["frames"], steps=c["steps"],
+                   guide=c["guide"], out=str(clip),
+                   memory_mode=c.get("memory_mode", "auto"),
+                   no_compile=c.get("no_compile", False), trim=c.get("trim", 0))
+        if c.get("lora"):
+            cfg["lh"] = [[f"{LIGHT}/high_noise_model.safetensors", 1.0]]
+            cfg["ll"] = [[f"{LIGHT}/low_noise_model.safetensors", 1.0]]
+        print(f"[case] {c['name']}", flush=True)
+        t0 = time.time()
+        p = subprocess.run([PY, str(runner), json.dumps(cfg)],
+                           capture_output=True, text=True, timeout=40 * 60)
+        ok = clip.exists() and "RUN_OK" in p.stdout
+        rec = dict(name=c["name"], ok=ok, wall=round(time.time() - t0, 1))
+        if ok:
+            rec["luma"] = round(luma(clip), 1)
+            rec["black"] = rec["luma"] < 8.0
+        else:
+            rec["tail"] = (p.stdout + p.stderr).splitlines()[-6:]
+        results.append(rec)
+        print(f"[done] {json.dumps(rec)}", flush=True)
+
+    # pytest: contract (with weights) + weight-free suite
+    env_q4 = str(MODELS / "Wan2.2-I2V-A14B-MLX-Q4")
+    p = subprocess.run(
+        [PY, "-m", "pytest", "tests/test_wan_relay.py", "tests/test_rope.py",
+         "tests/test_vae_streaming.py", "-q"],
+        capture_output=True, text=True, cwd=str(FORK), timeout=40 * 60,
+        env={**__import__("os").environ, "WAN22_A14B_DIR": env_q4,
+             "PYTHONPATH": str(FORK)},
+    )
+    pytest_tail = p.stdout.splitlines()[-3:]
+    print("[pytest]", pytest_tail, flush=True)
+
+    (OUT / "matrix_results.json").write_text(json.dumps(
+        dict(cases=results, pytest=pytest_tail), indent=1))
+    n_bad = sum(1 for r in results if not r["ok"] or r.get("black"))
+    print(f"MATRIX COMPLETE bad={n_bad}/{len(results)}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wan_relay.py
+++ b/tests/test_wan_relay.py
@@ -1,0 +1,71 @@
+"""Tests for Wan2.2 dual-expert relay-shedding (memory_mode).
+
+The core correctness contract — memory_mode="relay" and memory_mode="parallel"
+produce BIT-IDENTICAL latents for the same seed — needs real A14B weights, so
+the full contract test is opt-in: point WAN22_A14B_DIR at a converted dual
+model dir and it will run two short generations and compare the dumped
+pre-VAE latents byte-for-byte. (Validated during development on an M5 Pro
+48GB against both the 4-bit and bf16 conversions: MD5-identical latents;
+bf16 A14B peaked at 36.8GB in relay mode at 832x480x81f.)
+
+The unit tests below run without weights.
+"""
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+A14B_DIR = os.environ.get("WAN22_A14B_DIR", "")
+
+
+def test_memory_mode_validated():
+    """A typo'd memory_mode must fail loudly, not silently load both experts."""
+    from mlx_video.models.wan_2.generate import generate_video
+
+    with pytest.raises(ValueError, match="memory_mode"):
+        generate_video(
+            model_dir="/nonexistent",
+            prompt="x",
+            memory_mode="relai",
+        )
+
+
+def test_cli_exposes_memory_mode():
+    out = subprocess.run(
+        [sys.executable, "-m", "mlx_video.models.wan_2.generate", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert "--memory-mode" in out.stdout
+    assert "--dump-latents" in out.stdout
+
+
+@pytest.mark.skipif(not A14B_DIR, reason="set WAN22_A14B_DIR to a converted dual-model dir")
+def test_relay_parallel_bit_identical():
+    """Same seed, relay vs parallel: pre-VAE latents must match byte-for-byte."""
+    from mlx_video.models.wan_2.generate import generate_video
+
+    digests = {}
+    with tempfile.TemporaryDirectory() as td:
+        for mode in ("parallel", "relay"):
+            lat = Path(td) / f"{mode}.npy"
+            generate_video(
+                model_dir=A14B_DIR,
+                prompt="a red cube on a wooden table, studio light",
+                width=448,
+                height=256,
+                num_frames=9,
+                steps=4,
+                guide_scale="1",
+                seed=42,
+                output_path=str(Path(td) / f"{mode}.mp4"),
+                tiling="aggressive",
+                memory_mode=mode,
+                dump_latents=str(lat),
+            )
+            digests[mode] = hashlib.md5(lat.read_bytes()).hexdigest()
+    assert digests["parallel"] == digests["relay"]

--- a/tests/test_wan_relay.py
+++ b/tests/test_wan_relay.py
@@ -46,16 +46,26 @@ def test_cli_exposes_memory_mode():
 
 @pytest.mark.skipif(not A14B_DIR, reason="set WAN22_A14B_DIR to a converted dual-model dir")
 def test_relay_parallel_bit_identical():
-    """Same seed, relay vs parallel: pre-VAE latents must match byte-for-byte."""
+    """Same seed, relay vs parallel: pre-VAE latents must match byte-for-byte.
+
+    A14B checkpoints are typically I2V (in_dim=36, image conditioning
+    required), so a synthetic keyframe is generated on the fly; T2V dual
+    models work the same way with image=None.
+    """
+    from PIL import Image
+
     from mlx_video.models.wan_2.generate import generate_video
 
     digests = {}
     with tempfile.TemporaryDirectory() as td:
+        img = Path(td) / "key.png"
+        Image.new("RGB", (448, 256), (90, 110, 140)).save(img)
         for mode in ("parallel", "relay"):
             lat = Path(td) / f"{mode}.npy"
             generate_video(
                 model_dir=A14B_DIR,
                 prompt="a red cube on a wooden table, studio light",
+                image=str(img),
                 width=448,
                 height=256,
                 num_frames=9,


### PR DESCRIPTION
Up-front honesty, in the spirit of #20: this work was done with heavy AI assistance (Claude — Fable 5) and I'm not a professional ML engineer. I've validated everything I could on-device (numbers below are all real measured runs I can share), and I'd genuinely welcome expert scrutiny on anything I may have missed.

## Overview

The Wan2.2 A14B dual model switches experts **once**, at a deterministic timestep boundary — but both experts are loaded eagerly and stay resident for the whole denoise (~2× weights). That forces quantization on 48GB machines, and quantization currently costs real quality (#40: the quantized CFG path also produces black clips at 81f).

This PR adds `memory_mode="relay"`: build the high-noise expert, run the high phase, free it at the boundary, build the low-noise expert. Peak ≈ **one** expert + activations.

**Headline: Wan2.2 A14B bf16 goes from impossible-on-48GB to 36.8GB peak** (832×480, 81f, Lightning) / 44.3GB with CFG — with **no wall-clock penalty** (bf16 relay was the fastest config tested: 27.9 min at 20 steps vs 28.7–29.1 for the quantized variants; the boundary reload costs ~3s from a warm page cache).

## Modes

- `auto` (default) — relay for dual models, unchanged behavior for single
- `relay` — one expert resident, swapped at the boundary
- `parallel` — both resident (previous behavior)
- typos fail fast with `ValueError` (a silently-unknown mode would degenerate into both-resident with no warning)

## Correctness contract — full seed reproducibility

Relay changes only **when** weights are resident, never the math. Verified on-device, all three directions:

- **current main vs this branch (parallel): byte-identical mp4** for the same seed (MD5-equal files) — zero behavior change for existing users;
- **parallel vs relay: bit-identical pre-VAE latents** (MD5; opt-in pytest contract test included, set `WAN22_A14B_DIR`);
- therefore relay reproduces exactly what previous releases produced.

How: model construction consumes the global PRNG stream (keyless layer inits AND the `nn.quantize` stub constructors), and the noise is drawn after both experts are built. Relay defers the real builds, so it pre-consumes the same draws with two discarded **lazy** replicas of the loader path (never evaluated, near-zero cost). Known exception, documented in code: quantized + LoRA in relay mode stays deterministic per-mode but is not seed-identical to parallel (the LoRA dequant-merge constructs extra layers whose RNG use depends on the LoRA configs).

## Second commit (standalone fix)

`fix(wan2.2): release transformer weights before VAE decode` — the cleanup deletes the model variables but not the loop locals (`_call` — the mx.compile wrapper — retains the model through its traced graph), so the last-used transformer stayed fully resident through the whole VAE decode. Applies to stock parallel mode too.

## Measured (M5 Pro 48GB, macOS 26.5.1, mlx 0.31.2, seed 42, 832×480×81f)

| config | peak | wall | notes |
|---|---|---|---|
| bf16 relay, Lightning 4-step, guide=1 | 36.8GB | 7.3 min | previously impossible on 48GB |
| bf16 relay, 20 steps guide=1 | 36.8GB | 27.9 min | fastest 20-step config tested |
| bf16 relay, 20 steps CFG 3.5,3.5 | 44.3GB | 53 min | CFG works (quantized CFG at 81f is black — #40) |
| Q4 parallel (baseline) | 36.8GB | 28.7 min | |

Quality context (same seed/prompt across a precision ladder): rendered TEXT with quantization ≤8-bit came out as broken glyphs in every mix we tried; bf16 renders real letters.

**Before/after clips** (5s, seed 42):
- before — [Q4 + Lightning, the 48GB status quo: glyph-soup signage](https://raw.githubusercontent.com/lBroth/mlx-video/evidence/evidence/before_q4_lightning_glyphsoup.mp4)
- after — [bf16 relay + CFG: legible neon sign](https://raw.githubusercontent.com/lBroth/mlx-video/evidence/evidence/after_bf16_relay_cfg_videboom.mp4) · [bf16 relay + Lightning, 7.3 min (faster than Q4)](https://raw.githubusercontent.com/lBroth/mlx-video/evidence/evidence/after_bf16_relay_lightning_7min.mp4) · [bf16 relay + CFG, face](https://raw.githubusercontent.com/lBroth/mlx-video/evidence/evidence/after_bf16_relay_cfg_face.mp4)

## Usage

```bash
python -m mlx_video.models.wan_2.generate \
  --model-dir Wan2.2-I2V-A14B-MLX-bf16 --image key.png \
  --prompt "..." --num-frames 81 --steps 20 --guide-scale 3.5,3.5 \
  --memory-mode relay --tiling aggressive
```

## Tests

- `tests/test_wan_relay.py`: mode validation, CLI surface, opt-in bit-identity contract test (`WAN22_A14B_DIR`)
- local run: `42 passed, 1 skipped` (note: `tests/test_generate_dev.py` fails collection on main too — it imports `mlx_video.generate_dev`, which no longer exists; happy to fix in a follow-up if wanted)
- regression matrix on this branch (M5 Pro 48GB): 5B single-model CFG, 5B T2V (no image), Q4+Lightning parallel (LoRA merge path), Q4+CFG relay, bf16 relay no_compile — all green, no black clips. (`trim_first_frames` + I2V crashes identically on current main — pre-existing, unrelated.)
